### PR TITLE
fix: Update agent token in consul-common.sh

### DIFF
--- a/modules/run-consul/consul-common.sh
+++ b/modules/run-consul/consul-common.sh
@@ -509,5 +509,5 @@ function set_agent_token {
     token_arg=""
   fi
 
-  consul acl set-agent-token $token_arg agent "$token"
+  consul acl set-agent-token $token_arg agent "$agent_token"
 }


### PR DESCRIPTION
I have wrongly used the bootstrap token for all the consul agents, which later we identified when we rotated our tokens. 
its a bug in the module. its unusual for the bootstrap token to be stored on all consul agents, hence fixing it.