### PR TITLE
grunwork aws library upgrade to 0.2.4

### DIFF
--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -132,7 +132,7 @@ function install_dependencies {
   fi
 
   sudo mkdir -p /opt/gruntwork
-  git clone --branch v0.1.9 https://github.com/gruntwork-io/bash-commons.git /tmp/bash-commons
+  git clone --branch v0.2.4 https://github.com/gruntwork-io/bash-commons.git /tmp/bash-commons
   sudo cp -r /tmp/bash-commons/modules/bash-commons/src /opt/gruntwork/bash-commons
 
 }


### PR DESCRIPTION
this also helps set the aws ec2 metadata fetch to use the default imdsv2.

